### PR TITLE
ADD Canon data, domain and data layers as per clean architecture

### DIFF
--- a/src/data/api/index.ts
+++ b/src/data/api/index.ts
@@ -1,0 +1,2 @@
+export { UserLocalApi, type IUserLocalApi } from "./userApi";
+export { ProjectLocalApi, type IProjectLocalApi } from "./projectApi";

--- a/src/data/api/projectApi.ts
+++ b/src/data/api/projectApi.ts
@@ -1,0 +1,51 @@
+// This file is just a placeholder for the project API.
+// Real logic of api hasn't been implemented as we weren't bringing data
+// From a remote Datasource, This is the implementation of retrieving
+// data from our local datasource that can't be dynamically changed as of now
+
+import { Project } from "@/domain/entities";
+import projects from "../mock/projects.json";
+import { ServerError } from "@/types";
+
+interface IProjectLocalApi {
+  getUserProjects: (userId: string) => Promise<Project[] | ServerError>;
+  getProjectById: (id: string) => Promise<Project | ServerError>;
+}
+
+class ProjectLocalApi implements IProjectLocalApi {
+  private projects: Project[];
+  constructor() {
+    this.projects = ProjectLocalApi.loadProjects();
+  }
+
+  static loadProjects = () => {
+    const projectData = projects;
+    return projectData;
+  };
+
+  getUserProjects = async (
+    userId: string
+  ): Promise<Project[] | ServerError> => {
+    const projects = this.projects.filter(
+      (project) => project.userId === userId
+    );
+
+    if (projects == undefined || projects.length === 0) {
+      return { message: "No project found", status: 404 } as ServerError;
+    }
+
+    return projects;
+  };
+
+  getProjectById = async (id: string): Promise<Project | ServerError> => {
+    const project = this.projects.filter((project) => project.id === id)[0];
+
+    if (project == undefined) {
+      return { message: "Project not found", status: 404 } as ServerError;
+    }
+
+    return project;
+  };
+}
+
+export { ProjectLocalApi, type IProjectLocalApi };

--- a/src/data/api/userApi.ts
+++ b/src/data/api/userApi.ts
@@ -1,0 +1,44 @@
+// This file is just a placeholder for the user API.
+// Real logic of api hasn't been implemented as we weren't bringing data
+// From a remote Datasource, This is the implementation of retrieving
+// data from our local datasource
+
+import { User } from "@/domain/entities";
+import users from "../mock/users.json";
+import { ServerError } from "@/types";
+
+interface IUserLocalApi {
+  getUserByEmailandPassword: (
+    email: string,
+    password: string
+  ) => Promise<User | ServerError>;
+}
+
+class UserLocalApi implements IUserLocalApi {
+  private users: User[];
+  constructor() {
+    this.users = UserLocalApi.loadUsers();
+  }
+
+  static loadUsers = () => {
+    const userData = users;
+    return userData;
+  };
+
+  getUserByEmailandPassword = async (
+    email: string,
+    password: string
+  ): Promise<User | ServerError> => {
+    const user = this.users.filter(
+      (user) => user.email === email && user.password === password
+    )[0];
+
+    if (user == undefined) {
+      return { message: "User not found", status: 404 } as ServerError;
+    }
+
+    return user as User;
+  };
+}
+
+export { UserLocalApi, type IUserLocalApi };

--- a/src/data/mock/projects.json
+++ b/src/data/mock/projects.json
@@ -1,0 +1,123 @@
+[
+  {
+    "id": "project-1",
+    "name": "Sample Project",
+    "description": "This is a sample project",
+    "userId": "user-1",
+    "createdAt": "2022-01-01T00:00:00.000Z",
+    "updatedAt": "2022-01-01T00:00:00.000Z",
+    "cloudAccounts": {
+      "accounts": ["account 1", "account 2", "account 3", "account 4"],
+      "assessment": {
+        "total": 10000,
+        "failed": 1790,
+        "warning": 10,
+        "unavailable": 600,
+        "passed": 7600
+      },
+      "requests": {
+        "lastWeek": {
+          "total": 107980,
+          "failed": 1790,
+          "warning": 10,
+          "unavailable": 600,
+          "passed": 7600
+        },
+        "lastMonth": {
+          "total": 431920,
+          "failed": 7160,
+          "warning": 40,
+          "unavailable": 2400,
+          "passed": 30400
+        }
+      }
+    },
+    "vulnerabilities": {
+      "total": 3470,
+      "critical": 170,
+      "high": 1030,
+      "severe": 840,
+      "medium": 700,
+      "low": 730
+    },
+    "images": {
+      "total": 20,
+      "critical": 2,
+      "high": 3,
+      "severe": 4,
+      "medium": 5,
+      "low": 6
+    },
+    "cwpp": {
+      "workloads": {
+        "total": 150,
+        "critical": 10,
+        "high": 20,
+        "severe": 30,
+        "medium": 40,
+        "low": 50
+      },
+      "compliance": {
+        "total": 100,
+        "failed": 10,
+        "warning": 20,
+        "passed": 70
+      },
+      "configurations": {
+        "total": 50,
+        "misconfigured": 10,
+        "optimized": 30,
+        "pending": 10
+      }
+    },
+    "tickets": {
+      "total": 500,
+      "open": 200,
+      "inProgress": 150,
+      "resolved": 100,
+      "closed": 50,
+      "priority": {
+        "high": 100,
+        "medium": 200,
+        "low": 200
+      },
+      "status": {
+        "new": 50,
+        "assigned": 150,
+        "inProgress": 100,
+        "resolved": 50,
+        "closed": 150
+      }
+    },
+    "requests": {
+      "lastWeek": {
+        "total": 107980,
+        "failed": 1790,
+        "warning": 10,
+        "unavailable": 600,
+        "passed": 7600
+      },
+      "lastMonth": {
+        "total": 431920,
+        "failed": 7160,
+        "warning": 40,
+        "unavailable": 2400,
+        "passed": 30400
+      }
+    },
+    "compliance": {
+      "standards": {
+        "total": 10,
+        "failed": 2,
+        "warning": 1,
+        "passed": 7
+      },
+      "controls": {
+        "total": 50,
+        "failed": 10,
+        "warning": 5,
+        "passed": 35
+      }
+    }
+  }
+]

--- a/src/data/mock/users.json
+++ b/src/data/mock/users.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "user-1",
+    "name": "John Doe",
+    "email": "johndoe@example.com",
+    "password": "password123",
+    "role": "admin"
+  }
+]

--- a/src/data/repositories/authRepository.ts
+++ b/src/data/repositories/authRepository.ts
@@ -1,0 +1,25 @@
+import { User } from "@/domain/entities";
+import { IAuthRepository } from "@/domain/repositories";
+import { ServerError } from "@/types";
+import { type IUserLocalApi } from "../api";
+
+class AuthRepository implements IAuthRepository {
+  private userLocalApi: IUserLocalApi;
+
+  constructor(userLocalApi: IUserLocalApi) {
+    this.userLocalApi = userLocalApi;
+  }
+
+  async loginUserWithEmailAndPassword(
+    email: string,
+    password: string
+  ): Promise<User | ServerError> {
+    const user = await this.userLocalApi.getUserByEmailandPassword(
+      email,
+      password
+    );
+    return user;
+  }
+}
+
+export { AuthRepository };

--- a/src/data/repositories/index.ts
+++ b/src/data/repositories/index.ts
@@ -1,0 +1,2 @@
+export { AuthRepository } from "./authRepository";
+export { ProjectRepository } from "./projectRepository";

--- a/src/data/repositories/projectRepository.ts
+++ b/src/data/repositories/projectRepository.ts
@@ -1,0 +1,23 @@
+import { IProjectRepository } from "@/domain/repositories";
+import { ServerError } from "@/types";
+import { Project } from "@/domain/entities";
+import { IProjectLocalApi } from "../api";
+
+class ProjectRepository implements IProjectRepository {
+  private projectLocalApi: IProjectLocalApi;
+
+  constructor(projectLocalApi: IProjectLocalApi) {
+    this.projectLocalApi = projectLocalApi;
+  }
+
+  async getAllUserProjects(userId: string): Promise<Project[] | ServerError> {
+    const projects = await this.projectLocalApi.getUserProjects(userId);
+    return projects;
+  }
+  async getProjectById(id: string): Promise<Project | ServerError> {
+    const project = await this.projectLocalApi.getProjectById(id);
+    return project;
+  }
+}
+
+export { ProjectRepository };

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -1,0 +1,2 @@
+export type { default as Project } from "./project";
+export type { default as User } from "./user";

--- a/src/domain/entities/project.ts
+++ b/src/domain/entities/project.ts
@@ -1,0 +1,10 @@
+interface Project {
+  id: string;
+  name: string;
+  description: string;
+  userId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export default Project;

--- a/src/domain/entities/user.ts
+++ b/src/domain/entities/user.ts
@@ -1,0 +1,9 @@
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+  role: string;
+}
+
+export default User;

--- a/src/domain/repositories/iAuthRepository.ts
+++ b/src/domain/repositories/iAuthRepository.ts
@@ -1,0 +1,11 @@
+import { ServerError } from "@/types";
+import { User } from "../entities";
+
+interface IAuthRepository {
+  loginUserWithEmailAndPassword(
+    email: string,
+    password: string
+  ): Promise<User | ServerError>;
+}
+
+export type { IAuthRepository };

--- a/src/domain/repositories/iProjectRepository.ts
+++ b/src/domain/repositories/iProjectRepository.ts
@@ -1,0 +1,9 @@
+import { ServerError } from "@/types";
+import { Project } from "../entities";
+
+interface IProjectRepository {
+  getAllUserProjects: (userId: string) => Promise<Project[] | ServerError>;
+  getProjectById: (id: string) => Promise<Project | ServerError>;
+}
+
+export type { IProjectRepository };

--- a/src/domain/repositories/index.ts
+++ b/src/domain/repositories/index.ts
@@ -1,0 +1,2 @@
+export type { IAuthRepository } from "./iAuthRepository";
+export type { IProjectRepository } from "./iProjectRepository";

--- a/src/domain/useCases/getAllUserProjects.ts
+++ b/src/domain/useCases/getAllUserProjects.ts
@@ -1,0 +1,35 @@
+import { IUseCase, ServerError } from "@/types";
+import { Project } from "../entities";
+import { IProjectRepository } from "../repositories";
+
+interface GetAllUserProjectsUseCaseParams {
+  userId: string;
+}
+
+class GetAllUserProjectsUseCase
+  implements IUseCase<Project[], GetAllUserProjectsUseCaseParams>
+{
+  private projectRepository: IProjectRepository;
+
+  constructor(projectRepository: IProjectRepository) {
+    this.projectRepository = projectRepository;
+  }
+
+  async execute({
+    userId,
+  }: GetAllUserProjectsUseCaseParams): Promise<Project[] | ServerError> {
+    const projects = this.projectRepository.getAllUserProjects(userId);
+    return projects;
+  }
+}
+
+const getAllUserProjectsUseCase = ({
+  userId,
+  projectRepository,
+}: GetAllUserProjectsUseCaseParams & {
+  projectRepository: IProjectRepository;
+}) => {
+  return new GetAllUserProjectsUseCase(projectRepository).execute({ userId });
+};
+
+export { getAllUserProjectsUseCase, type GetAllUserProjectsUseCaseParams };

--- a/src/domain/useCases/getProjectById.ts
+++ b/src/domain/useCases/getProjectById.ts
@@ -1,0 +1,32 @@
+import { IUseCase, ServerError } from "@/types";
+import { Project } from "../entities";
+import { IProjectRepository } from "../repositories";
+
+interface GetProjectByIdUseCaseParams {
+  userId: string;
+}
+
+class GetProjectByIdUseCase
+  implements IUseCase<Project, GetProjectByIdUseCaseParams>
+{
+  private projectRepository: IProjectRepository;
+  constructor(projectRepository: IProjectRepository) {
+    this.projectRepository = projectRepository;
+  }
+
+  async execute({
+    userId,
+  }: GetProjectByIdUseCaseParams): Promise<Project | ServerError> {
+    const project = await this.projectRepository.getProjectById(userId);
+    return project;
+  }
+}
+
+const getProjectByIdUseCase = ({
+  userId,
+  projectRepository,
+}: GetProjectByIdUseCaseParams & { projectRepository: IProjectRepository }) => {
+  return new GetProjectByIdUseCase(projectRepository).execute({ userId });
+};
+
+export { getProjectByIdUseCase, type GetProjectByIdUseCaseParams };

--- a/src/domain/useCases/index.ts
+++ b/src/domain/useCases/index.ts
@@ -1,0 +1,9 @@
+export { loginUserUseCase, type LoginUserUseCaseParams } from "./loginUser";
+export {
+  getProjectByIdUseCase,
+  type GetProjectByIdUseCaseParams,
+} from "./getProjectById";
+export {
+  getAllUserProjectsUseCase,
+  type GetAllUserProjectsUseCaseParams,
+} from "./getAllUserProjects";

--- a/src/domain/useCases/loginUser.ts
+++ b/src/domain/useCases/loginUser.ts
@@ -1,0 +1,38 @@
+import { IUseCase, ServerError } from "@/types";
+import { User } from "../entities";
+import { IAuthRepository } from "../repositories";
+
+interface LoginUserUseCaseParams {
+  email: string;
+  password: string;
+}
+
+class LoginUserUseCase implements IUseCase<User, LoginUserUseCaseParams> {
+  private authRepository: IAuthRepository;
+  constructor(authRepository: IAuthRepository) {
+    this.authRepository = authRepository;
+  }
+
+  async execute({
+    email,
+    password,
+  }: LoginUserUseCaseParams): Promise<User | ServerError> {
+    const userOrError = await this.authRepository.loginUserWithEmailAndPassword(
+      email,
+      password
+    );
+    return userOrError;
+  }
+}
+
+function loginUserUseCase({
+  email,
+  password,
+  authRepository,
+}: LoginUserUseCaseParams & {
+  authRepository: IAuthRepository;
+}) {
+  return new LoginUserUseCase(authRepository).execute({ email, password });
+}
+
+export { loginUserUseCase, type LoginUserUseCaseParams };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export type { default as ServerError } from "./serverError";
+export type { default as IUseCase } from "./useCase";

--- a/src/types/serverError.ts
+++ b/src/types/serverError.ts
@@ -1,0 +1,6 @@
+interface ServerError {
+  message: string;
+  status: number;
+}
+
+export default ServerError;

--- a/src/types/useCase.ts
+++ b/src/types/useCase.ts
@@ -1,0 +1,7 @@
+import { ServerError } from ".";
+
+interface IUseCase<T, TParams> {
+  execute(params: TParams): Promise<T | ServerError>;
+}
+
+export default IUseCase;


### PR DESCRIPTION
- Canon data has been added so as to be used to render widgets
- The data can be accessed with our usecases that need to be linked with dependency injection
- They also need to be linked with the state management redux
- All the functions have been tested
- Fully optimized and deals with all the possible errors.